### PR TITLE
Fix fatal error when options {} is not defined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class Client_MySQL_deadlock extends Client_MySQL {
   constructor(config) {
     super(config);
 
-    const { deadlockRetries } = config.options;
+    const { deadlockRetries } = config.options || {};
 
     this.deadlockRetries = deadlockRetries || 5;
   }


### PR DESCRIPTION
Getting `TypeError: Cannot match against 'undefined' or 'null'.` when no options are passed in.