### PR TITLE
Corrects usage of retryAmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ class Client_MySQL_deadlock extends Client_MySQL {
 
     const runQuery = () => Reflect.apply(super._query, this, arguments)
       .catch(error => {
-        if (error.code === 'ER_LOCK_WAIT_TIMEOUT' && --retryAmount > 0) {
-          console.log(`${error.code} returned, retrying, (${retryAmount}) tries remaning: ${util.inspect(arguments, {depth:2})}`);
+        if (error.code === 'ER_LOCK_WAIT_TIMEOUT' && retryAmount-- > 0) {
+          console.log(`${error.code} returned, retrying, (${retryAmount}) tries remaining before error: ${util.inspect(arguments, {depth:2})}`);
 
           return runQuery();
         }


### PR DESCRIPTION
"retryAmount" implies that there is some number of retries that should be attempted.  With the prefix decrement, this is not the case.  That operator treats "retryAmount" as the total number of query attempts.  I have switched it to a postfix decrement to ensure that it instead reflects the number of retries that should be performed.
A minor typo in log message was addressed, too.